### PR TITLE
Continuous Delivery Workflow

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -2,8 +2,8 @@ name: Continuous Delivery
 
 on:
     push:
-        branches:
-            - master
+        tags:
+            - "v*"
 
 jobs:
     build:

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -81,15 +81,6 @@ jobs:
                   asset_name: nxDumpMerger_Windows_${{ matrix.architecture }}.exe
                   asset_content_type: application/x-dosexec
 
-            - name: Save the GitHub Release URL
-              run: echo ${{ steps.create_release.outputs.upload_url }} > upload_url.txt
-
-            - name: Upload the GitHub Release URL
-              uses: actions/upload-artifact@v2
-              with:
-                  name: upload_url
-                  path: upload_url.txt
-
     build-x64:
         runs-on: windows-latest
         needs: build-x86

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -36,14 +36,41 @@ jobs:
                   cd dist-file
                   move nxDumpMerger.exe ..\nxDumpMerger_Windows_${{ matrix.architecture }}.exe
 
-            - name: Upload artifact (one dir)
-              uses: actions/upload-artifact@v2
-              with:
-                  name: uploads
-                  path: nxDumpMerger_Windows_${{ matrix.architecture }}.zip
+            - name: Get the tag version
+              id: get_version
+              run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+              shell: bash
 
-            - name: Upload artifact (one file)
-              uses: actions/upload-artifact@v2
+            - name: Create release
+              id: create_release
+              uses: actions/create-release@v1
               with:
-                  name: uploads
-                  path: nxDumpMerger_Windows_${{ matrix.architecture }}.exe
+                  tag_name: ${{ steps.get_version.outputs.VERSION }}
+                  release_name: ${{ steps.get_version.outputs.VERSION }}
+                  draft: false
+                  prerelease: false
+                  token: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Upload release asset (python script)
+              uses: actions/upload-release-asset@v1
+              with:
+                  upload_url: ${{ steps.create_release.outputs.upload_url }}
+                  asset_path: nxDumpMerger.py
+                  asset_name: nxDumpMerger.py
+                  asset_content_type: text/x-python
+
+            - name: Upload release asset (builded dir)
+              uses: actions/upload-release-asset@v1
+              with:
+                  upload_url: ${{ steps.create_release.outputs.upload_url }}
+                  asset_path: nxDumpMerger_Windows_${{ matrix.architecture }}.zip
+                  asset_name: nxDumpMerger_Windows_${{ matrix.architecture }}.zip
+                  asset_content_type: application/zip
+
+            - name: Upload release asset (builded one file)
+              uses: actions/upload-release-asset@v1
+              with:
+                  upload_url: ${{ steps.create_release.outputs.upload_url }}
+                  asset_path: nxDumpMerger_Windows_${{ matrix.architecture }}.exe
+                  asset_name: nxDumpMerger_Windows_${{ matrix.architecture }}.exe
+                  asset_content_type: application/x-dosexec

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -6,11 +6,10 @@ on:
             - "v*"
 
 jobs:
-    build:
+    build-x86:
         runs-on: windows-latest
-        strategy:
-            matrix:
-                architecture: ["x86", "x64"]
+        outputs:
+              upload_url: ${{ steps.create_release.outputs.upload_url }}
 
         steps:
             - uses: actions/checkout@v2
@@ -19,7 +18,7 @@ jobs:
               uses: actions/setup-python@v2
               with:
                   python-version: "3.6"
-                  architecture: ${{ matrix.architecture }}
+                  architecture: "x86"
 
             - name: Install pyinstaller
               run: python -m pip install pyinstaller
@@ -28,13 +27,13 @@ jobs:
               run: |
                   python -m PyInstaller -w -D --clean -y --distpath dist-dir nxDumpMerger.py
                   cd dist-dir
-                  powershell Compress-Archive nxDumpMerger ..\nxDumpMerger_Windows_${{ matrix.architecture }}.zip
+                  powershell Compress-Archive nxDumpMerger ..\nxDumpMerger_Windows_x86.zip
 
             - name: Build package to one file
               run: |
                   python -m PyInstaller -w -F --clean -y --distpath dist-file nxDumpMerger.py
                   cd dist-file
-                  move nxDumpMerger.exe ..\nxDumpMerger_Windows_${{ matrix.architecture }}.exe
+                  move nxDumpMerger.exe ..\nxDumpMerger_Windows_x86.exe
 
             - name: Get the tag version
               id: get_version
@@ -68,6 +67,73 @@ jobs:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               with:
                   upload_url: ${{ steps.create_release.outputs.upload_url }}
+                  asset_path: nxDumpMerger_Windows_${{ matrix.architecture }}.zip
+                  asset_name: nxDumpMerger_Windows_${{ matrix.architecture }}.zip
+                  asset_content_type: application/zip
+
+            - name: Upload release asset (builded one file)
+              uses: actions/upload-release-asset@v1
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              with:
+                  upload_url: ${{ steps.create_release.outputs.upload_url }}
+                  asset_path: nxDumpMerger_Windows_${{ matrix.architecture }}.exe
+                  asset_name: nxDumpMerger_Windows_${{ matrix.architecture }}.exe
+                  asset_content_type: application/x-dosexec
+
+            - name: Save the GitHub Release URL
+              run: echo ${{ steps.create_release.outputs.upload_url }} > upload_url.txt
+
+            - name: Upload the GitHub Release URL
+              uses: actions/upload-artifact@v2
+              with:
+                  name: upload_url
+                  path: upload_url.txt
+
+    build-x64:
+        runs-on: windows-latest
+        needs: build-x86
+
+        steps:
+            - uses: actions/checkout@v2
+
+            - name: Setup Python
+              uses: actions/setup-python@v2
+              with:
+                  python-version: "3.6"
+                  architecture: "x64"
+
+            - name: Install pyinstaller
+              run: python -m pip install pyinstaller
+
+            - name: Build package to one directory
+              run: |
+                  python -m PyInstaller -w -D --clean -y --distpath dist-dir nxDumpMerger.py
+                  cd dist-dir
+                  powershell Compress-Archive nxDumpMerger ..\nxDumpMerger_Windows_x64.zip
+
+            - name: Build package to one file
+              run: |
+                  python -m PyInstaller -w -F --clean -y --distpath dist-file nxDumpMerger.py
+                  cd dist-file
+                  move nxDumpMerger.exe ..\nxDumpMerger_Windows_x64.exe
+
+            - name: Upload release asset (python script)
+              uses: actions/upload-release-asset@v1
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              with:
+                  upload_url: ${{ needs.build-x86.outputs.upload_url }}
+                  asset_path: nxDumpMerger.py
+                  asset_name: nxDumpMerger.py
+                  asset_content_type: text/x-python
+
+            - name: Upload release asset (builded dir)
+              uses: actions/upload-release-asset@v1
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              with:
+                  upload_url: ${{ needs.build-x86.outputs.upload_url }}
                   asset_path: nxDumpMerger_Windows_${{ matrix.architecture }}.zip
                   asset_name: nxDumpMerger_Windows_${{ matrix.architecture }}.zip
                   asset_content_type: application/zip

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -44,12 +44,13 @@ jobs:
             - name: Create release
               id: create_release
               uses: actions/create-release@v1
+              env:
+                  token: ${{ secrets.GITHUB_TOKEN }}
               with:
                   tag_name: ${{ steps.get_version.outputs.VERSION }}
                   release_name: ${{ steps.get_version.outputs.VERSION }}
                   draft: false
                   prerelease: false
-                  token: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Upload release asset (python script)
               uses: actions/upload-release-asset@v1

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -118,24 +118,14 @@ jobs:
                   cd dist-file
                   move nxDumpMerger.exe ..\nxDumpMerger_Windows_x64.exe
 
-            - name: Upload release asset (python script)
-              uses: actions/upload-release-asset@v1
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-              with:
-                  upload_url: ${{ needs.build-x86.outputs.upload_url }}
-                  asset_path: nxDumpMerger.py
-                  asset_name: nxDumpMerger.py
-                  asset_content_type: text/x-python
-
             - name: Upload release asset (builded dir)
               uses: actions/upload-release-asset@v1
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               with:
                   upload_url: ${{ needs.build-x86.outputs.upload_url }}
-                  asset_path: nxDumpMerger_Windows_${{ matrix.architecture }}.zip
-                  asset_name: nxDumpMerger_Windows_${{ matrix.architecture }}.zip
+                  asset_path: nxDumpMerger_Windows_x64.zip
+                  asset_name: nxDumpMerger_Windows_x64.zip
                   asset_content_type: application/zip
 
             - name: Upload release asset (builded one file)
@@ -144,6 +134,6 @@ jobs:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               with:
                   upload_url: ${{ steps.create_release.outputs.upload_url }}
-                  asset_path: nxDumpMerger_Windows_${{ matrix.architecture }}.exe
-                  asset_name: nxDumpMerger_Windows_${{ matrix.architecture }}.exe
+                  asset_path: nxDumpMerger_Windows_x64.exe
+                  asset_name: nxDumpMerger_Windows_x64.exe
                   asset_content_type: application/x-dosexec

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -40,7 +40,7 @@ jobs:
               id: create_release
               uses: actions/create-release@v1
               env:
-                  token: ${{ secrets.GITHUB_TOKEN }}
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               with:
                   tag_name: ${{ github.ref }}
                   release_name: ${{ github.ref }}

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -124,7 +124,7 @@ jobs:
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               with:
-                  upload_url: ${{ steps.create_release.outputs.upload_url }}
+                  upload_url: ${{ needs.build-x86.outputs.upload_url }}
                   asset_path: nxDumpMerger_Windows_x64.exe
                   asset_name: nxDumpMerger_Windows_x64.exe
                   asset_content_type: application/x-dosexec

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -54,6 +54,8 @@ jobs:
 
             - name: Upload release asset (python script)
               uses: actions/upload-release-asset@v1
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               with:
                   upload_url: ${{ steps.create_release.outputs.upload_url }}
                   asset_path: nxDumpMerger.py
@@ -62,6 +64,8 @@ jobs:
 
             - name: Upload release asset (builded dir)
               uses: actions/upload-release-asset@v1
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               with:
                   upload_url: ${{ steps.create_release.outputs.upload_url }}
                   asset_path: nxDumpMerger_Windows_${{ matrix.architecture }}.zip
@@ -70,6 +74,8 @@ jobs:
 
             - name: Upload release asset (builded one file)
               uses: actions/upload-release-asset@v1
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               with:
                   upload_url: ${{ steps.create_release.outputs.upload_url }}
                   asset_path: nxDumpMerger_Windows_${{ matrix.architecture }}.exe

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -1,0 +1,49 @@
+name: Continuous Delivery
+
+on:
+    push:
+        branches:
+            - master
+
+jobs:
+    build:
+        runs-on: windows-latest
+        strategy:
+            matrix:
+                architecture: ["x86", "x64"]
+
+        steps:
+            - uses: actions/checkout@v2
+
+            - name: Setup Python
+              uses: actions/setup-python@v2
+              with:
+                  python-version: "3.6"
+                  architecture: ${{ matrix.architecture }}
+
+            - name: Install pyinstaller
+              run: python -m pip install pyinstaller
+
+            - name: Build package to one directory
+              run: |
+                  python -m PyInstaller -w -D --clean -y --distpath dist-dir nxDumpMerger.py
+                  cd dist-dir
+                  powershell Compress-Archive nxDumpMerger ..\nxDumpMerger_Windows_${{ matrix.architecture }}.zip
+
+            - name: Build package to one file
+              run: |
+                  python -m PyInstaller -w -F --clean -y --distpath dist-file nxDumpMerger.py
+                  cd dist-file
+                  move nxDumpMerger.exe ..\nxDumpMerger_Windows_${{ matrix.architecture }}.exe
+
+            - name: Upload artifact (one dir)
+              uses: actions/upload-artifact@v2
+              with:
+                  name: uploads
+                  path: nxDumpMerger_Windows_${{ matrix.architecture }}.zip
+
+            - name: Upload artifact (one file)
+              uses: actions/upload-artifact@v2
+              with:
+                  name: uploads
+                  path: nxDumpMerger_Windows_${{ matrix.architecture }}.exe

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -36,14 +36,19 @@ jobs:
                   cd dist-file
                   move nxDumpMerger.exe ..\nxDumpMerger_Windows_${{ matrix.architecture }}.exe
 
+            - name: Get the tag version
+              id: get_version
+              run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+              shell: bash
+
             - name: Create release
               id: create_release
               uses: actions/create-release@v1
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               with:
-                  tag_name: ${{ github.ref }}
-                  release_name: ${{ github.ref }}
+                  tag_name: ${{ steps.get_version.outputs.VERSION }}
+                  release_name: ${{ steps.get_version.outputs.VERSION }}
                   draft: false
                   prerelease: false
 

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -36,19 +36,14 @@ jobs:
                   cd dist-file
                   move nxDumpMerger.exe ..\nxDumpMerger_Windows_${{ matrix.architecture }}.exe
 
-            - name: Get the tag version
-              id: get_version
-              run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
-              shell: bash
-
             - name: Create release
               id: create_release
               uses: actions/create-release@v1
               env:
                   token: ${{ secrets.GITHUB_TOKEN }}
               with:
-                  tag_name: ${{ steps.get_version.outputs.VERSION }}
-                  release_name: ${{ steps.get_version.outputs.VERSION }}
+                  tag_name: ${{ github.ref }}
+                  release_name: ${{ github.ref }}
                   draft: false
                   prerelease: false
 

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -67,8 +67,8 @@ jobs:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               with:
                   upload_url: ${{ steps.create_release.outputs.upload_url }}
-                  asset_path: nxDumpMerger_Windows_${{ matrix.architecture }}.zip
-                  asset_name: nxDumpMerger_Windows_${{ matrix.architecture }}.zip
+                  asset_path: nxDumpMerger_Windows_x86.zip
+                  asset_name: nxDumpMerger_Windows_x86.zip
                   asset_content_type: application/zip
 
             - name: Upload release asset (builded one file)
@@ -77,8 +77,8 @@ jobs:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               with:
                   upload_url: ${{ steps.create_release.outputs.upload_url }}
-                  asset_path: nxDumpMerger_Windows_${{ matrix.architecture }}.exe
-                  asset_name: nxDumpMerger_Windows_${{ matrix.architecture }}.exe
+                  asset_path: nxDumpMerger_Windows_x86.exe
+                  asset_name: nxDumpMerger_Windows_x86.exe
                   asset_content_type: application/x-dosexec
 
     build-x64:

--- a/nxDumpMerger.py
+++ b/nxDumpMerger.py
@@ -14,7 +14,7 @@ else:
     from tkinter.ttk import Progressbar
 
 root = Tk()
-version = "1.0.0"
+version = "1.0.1"
 title = f"nxDumpMerger {version}"
 
 class App:

--- a/nxDumpMerger.py
+++ b/nxDumpMerger.py
@@ -14,8 +14,8 @@ else:
     from tkinter.ttk import Progressbar
 
 root = Tk()
-version = [1,0,0]
-title = f"nxDumpMerger {version[0]}.{version[1]}.{version[2]}"
+version = "1.0.0"
+title = f"nxDumpMerger {version}"
 
 class App:
     instructionString = "Select one file part and nxDumpMerger will automatically select the rest."


### PR DESCRIPTION
When you create a new tag in Git using Semantic Version for its name, the process of creating a Release in GitHub will automatically start, uploading the files "compiled" with PyInstaller for the x86 and x64 architectures on Windows, in addition to the Script .py.

You can see an example of how it works here: https://github.com/yonaikerlol/nxDumpMerger/releases/tag/v1.0.1